### PR TITLE
school is a string not and object here

### DIFF
--- a/app/Http/Controllers/admin/AdminReportController.php
+++ b/app/Http/Controllers/admin/AdminReportController.php
@@ -80,7 +80,7 @@ class AdminReportController extends AdminBaseController {
     // echo $times[0]->type;
 
     header('Content-Type: text/csv; charset=utf-8');
-    header('Content-Disposition: attachment; filename='.$school->name.'-'.$date.'.csv');
+    header('Content-Disposition: attachment; filename='.$school.'-'.$date.'.csv');
 
 
     $f = fopen('php://output', 'w');


### PR DESCRIPTION
Fixes a bug that was breaking csv output on reports.

Test: go to Reports, click on a date link on the left for a date that contains times (see graph above). Before fix, this results in an error, should result in prompt to download CSV data.

Working old site: http://pac12challenge.org/admin/reports
Broken current site: http://pac12.staging.osuosl.org/admin/reports

@aaroncohen73 