### PR TITLE
Kennric/remove mobile ref

### DIFF
--- a/resources/views/pages/welcome.blade.php
+++ b/resources/views/pages/welcome.blade.php
@@ -257,12 +257,7 @@ if (time() < strtotime('2014-02-24') && !Input::get('graphs')) {
 <div class="section s5">
     <img src="{{ asset('assets/images/section-3.png') }}" alt="" class="section-divider">
     <div class="row">
-        <div class="col-sm-6 col-xs-12">
-            <div class="area">
-                {!! $page->get_module_by_number(2) !!}
-            </div>
-        </div>
-        <div class="col-sm-6 col-xs-12">
+        <div class="col-sm-12 col-xs-12">
             <div class="section-image">
                 {!! $page->get_module_by_number(3) !!}
             </div>

--- a/resources/views/pages/welcome.blade.php
+++ b/resources/views/pages/welcome.blade.php
@@ -254,7 +254,7 @@ if (time() < strtotime('2014-02-24') && !Input::get('graphs')) {
     <p>For PAC-12 Challenge Events On Your Campus.</p>
 </div>
 
-<div class="section s5">
+<div class="section s3">
     <img src="{{ asset('assets/images/section-3.png') }}" alt="" class="section-divider">
     <div class="row">
         <div class="col-sm-12 col-xs-12">


### PR DESCRIPTION
Removes the section about mobile, as there is no mobile app this year. Centers the page module and removes the column that contained the mobile reference.