### PR TITLE
click on the icon should be module 2

### DIFF
--- a/resources/views/pages/welcome.blade.php
+++ b/resources/views/pages/welcome.blade.php
@@ -233,7 +233,7 @@ if (time() < strtotime('2014-02-24') && !Input::get('graphs')) {
 @endif
 <div class="section s3">
     <img src="{{ asset('assets/images/section-3.png') }}" alt="" class="section-divider">
-    {!! $page->get_module_by_number(1) !!}
+    {!! $page->get_module_by_number(2) !!}
     <div class="icons">
         @foreach($schools as $school)
             <a class="icon icon{{ $school->id }}" href="{{ $school->url }}" target="_blank"></a>


### PR DESCRIPTION
Page module numbers have diverged between staging and prod databases, since they are user-edited and not under our control now. This changes the page module referenced in the welcom page template for the "Click your school's icon" section.